### PR TITLE
Support environment injection tools for AUTUMN_SECRET_KEY

### DIFF
--- a/atmn/source/core/utils.ts
+++ b/atmn/source/core/utils.ts
@@ -80,10 +80,15 @@ export function storeToEnv(prodKey: string, sandboxKey: string) {
 }
 
 export function readFromEnv() {
+	// Check process.env first (highest priority - enables Doppler/env injection)
+	if (process.env['AUTUMN_SECRET_KEY']) {
+		return process.env['AUTUMN_SECRET_KEY'];
+	}
+
 	const envPath = `${process.cwd()}/.env`;
 	const envLocalPath = `${process.cwd()}/.env.local`;
 
-	// Check .env first (has priority)
+	// Check .env second
 	if (fs.existsSync(envPath)) {
 		const envContent = fs.readFileSync(envPath, 'utf-8');
 		const parsed = dotenv.parse(envContent);


### PR DESCRIPTION
## Issue
Currently, `atmn` only reads `AUTUMN_SECRET_KEY` from `.env` and `.env.local` files. This prevents using modern environment injection tools like  Doppler, Railway secrets, Vercel environment variables, Docker secrets, or Kubernetes ConfigMaps.

## Use Case
Many teams use environment injection tools for secret management instead of committing `.env` files. These tools set environment variables at runtime via `process.env`.

## Proposed Solution
Check `process.env.AUTUMN_SECRET_KEY` first before falling back to `.env` files. This maintains full backward compatibility while enabling environment  injection.

## Benefits
  - Works with any deployment platform or secret management tool
  - Maintains existing `.env` file workflow
  - Follows standard environment variable precedence patterns
  - Zero breaking changes

## Implementation
  Simple addition to `readFromEnv()` function - check `process.env` first, then existing `.env` file logic.