### PR TITLE
fix: 🐛 only need one of amount or flat_amount or both

### DIFF
--- a/atmn/src/compose/models/planModels.ts
+++ b/atmn/src/compose/models/planModels.ts
@@ -52,7 +52,7 @@ export const PlanItemSchema = z.object({
     }),
     tiers: z.array(UsageTierSchema).optional().meta({
     description:
-    "Tiered pricing. Each tier's 'to' does NOT include included amount. Either 'amount' or 'tiers' is required.",
+    "Tiered pricing.  Either 'amount' or 'tiers' is required.",
     }),
     tier_behavior: z.union([z.literal("graduated"), z.literal("volume")]).optional(),
     
@@ -245,7 +245,7 @@ type PriceWithAmount = PriceBaseFields & {
   tiers?: never;
 };
 
-// Price with graduated tiered pricing (no flat amount per tier)
+// Price with graduated tiered pricing (each tier's rate applies only to units within that tier)
 type PriceWithGraduatedTiers = PriceBaseFields & {
   /** Cannot have flat amount when using tiers */
   amount?: never;
@@ -255,14 +255,19 @@ type PriceWithGraduatedTiers = PriceBaseFields & {
   tierBehavior: "graduated";
 };
 
-// Price with volume tiered pricing (flat amount per tier)
+// Volume tier: at least one of amount or flatAmount must be present
+type VolumeTier =
+  | { to: number | "inf"; amount: number; flatAmount?: number }
+  | { to: number | "inf"; amount?: number; flatAmount: number };
+
+// Price with volume tiered pricing (the tier the total usage falls into applies to all units)
 type PriceWithVolumeTiers = Omit<PriceBaseFields, "billingMethod"> & {
   /** Volume pricing does not support usage_based billing — use 'prepaid' */
   billingMethod: Exclude<BillingMethod, "usage_based">;
   /** Cannot have flat amount when using tiers */
   amount?: never;
   /** Volume tiered pricing: the tier the total usage falls into applies to all units */
-  tiers: Array<{ to: number | "inf"; amount: number; flatAmount?: number }>;
+  tiers: Array<VolumeTier>;
   /** Volume: the rate of the tier the total usage falls into applies to all units */
   tierBehavior: "volume";
 };

--- a/typegen/genUtils/TypeGenerator.ts
+++ b/typegen/genUtils/TypeGenerator.ts
@@ -284,6 +284,7 @@ ${imports}
       OnDecrease: ['prorate', 'refund_immediately', 'no_action'],
       FreeTrialDuration: ['day', 'month', 'year'],
       TierBehaviours: ['graduated', 'volume'],
+      TierBehavior: ['graduated', 'volume'],
       ApiFeatureType: ['static', 'boolean', 'single_use', 'continuous_use', 'credit_system'],
       FeatureType: ['boolean', 'metered', 'credit_system'],
     };

--- a/typegen/genUtils/atmnTypeHelpers.ts
+++ b/typegen/genUtils/atmnTypeHelpers.ts
@@ -234,15 +234,34 @@ type PriceWithAmount = PriceBaseFields & {
   tiers?: never;
 };
 
-// Price with tiered pricing (no flat amount)
-type PriceWithTiers = PriceBaseFields & {
+// Price with graduated tiered pricing (each tier's rate applies only to units within that tier)
+type PriceWithGraduatedTiers = PriceBaseFields & {
   /** Cannot have flat amount when using tiers */
   amount?: never;
-  /** Tiered pricing structure based on usage ranges */
+  /** Graduated tiered pricing: each tier's amount applies only to units within that tier */
   tiers: Array<{ to: number | "inf"; amount: number }>;
-  /** Required when tiers is defined: how tiers are applied */
-  tierBehaviour: "graduated" | "volume";
+  /** Graduated: each tier's rate applies only to usage within that tier */
+  tierBehavior: "graduated";
 };
+
+// Volume tier: at least one of amount or flatAmount must be present
+type VolumeTier =
+  | { to: number | "inf"; amount: number; flatAmount?: number }
+  | { to: number | "inf"; amount?: number; flatAmount: number };
+
+// Price with volume tiered pricing (the tier the total usage falls into applies to all units)
+type PriceWithVolumeTiers = Omit<PriceBaseFields, "billingMethod"> & {
+  /** Volume pricing does not support usage_based billing — use 'prepaid' */
+  billingMethod: Exclude<BillingMethod, "usage_based">;
+  /** Cannot have flat amount when using tiers */
+  amount?: never;
+  /** Volume tiered pricing: the tier the total usage falls into applies to all units */
+  tiers: Array<VolumeTier>;
+  /** Volume: the rate of the tier the total usage falls into applies to all units */
+  tierBehavior: "volume";
+};
+
+type PriceWithTiers = PriceWithGraduatedTiers | PriceWithVolumeTiers;
 
 // Price must have either amount OR tiers (not both, not neither)
 type PriceAmountOrTiers = PriceWithAmount | PriceWithTiers;


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes tier validation so volume tiers can use amount, flatAmount, or both, and clarifies graduated vs volume behavior with stricter types. Standardizes the property name to tierBehavior and updates docs.

- **Bug Fixes**
  - Volume tiers require at least one of amount or flatAmount (both allowed).
  - A price must have either amount or tiers, not both.
  - Volume pricing disallows usage_based billing (use prepaid).
  - Added TierBehavior enum to typegen; updated schema and comments for clarity.

- **Migration**
  - Rename tierBehaviour to tierBehavior in any references.

<sup>Written for commit 4b6532c16fc453f311447c11c04a0de50d60ed26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves the type definitions for volume-tiered pricing to correctly model that either `amount` or `flatAmount` (or both) are valid per-tier, rather than requiring `amount` unconditionally. It also renames the old single `PriceWithTiers` into two more precise types (`PriceWithGraduatedTiers` and `PriceWithVolumeTiers`) and corrects the British-spelling `tierBehaviour` to `tierBehavior`.

**Key changes:**

- **Bug fixes | API changes** — `atmnTypeHelpers.ts` / `planModels.ts`: The old `PriceWithTiers` type (with a single `tierBehaviour: "graduated" | "volume"`) is replaced by a discriminated union: `PriceWithGraduatedTiers` (always requires `amount` per tier) and `PriceWithVolumeTiers` (uses the new `VolumeTier` union type that accepts `amount`, `flatAmount`, or both). The `VolumeTier` union correctly enforces that at least one of the two must be present. Note: this is a **breaking change** for callers who used `tierBehaviour` (British spelling).
- **Improvements** — `TypeGenerator.ts`: `TierBehavior` is added to the enum-to-literal-union replacement map, ensuring the corrected spelling is handled during code generation alongside the legacy `TierBehaviours` key.
- **Bug fixes** — `planModels.ts`: The `tiers` field JSDoc description is trimmed, removing the now-stale note about `to` not including included amounts; graduated-tier comment is made more precise.

**Critical issue:** The `UsageTierSchema` Zod object (auto-generated, used for runtime validation of `tiers`) still defines `amount: z.number()` as a **required** field and has no `flatAmount` field at all. The new TypeScript `VolumeTier` type permits objects where `amount` is absent and only `flatAmount` is provided — those objects will pass TypeScript's type checker but **fail Zod runtime validation**. The underlying Zod schema (hardcoded in `TypeGenerator.ts` line 334 and output to `planModels.ts` lines 7–10) must be updated to include an optional `flatAmount` field and make `amount` optional, with a `.refine()` check to enforce at least one is present.
</details>


<h3>Confidence Score: 2/5</h3>

- Not safe to merge: TypeScript types and Zod runtime schemas are out of sync, risking silent validation failures.
- The TypeScript type improvements in `atmnTypeHelpers.ts` are correct and will enable the desired flexibility for volume tiers (allowing `amount` to be optional when `flatAmount` is present). However, the companion Zod schema used for runtime validation was not updated to match. Any volume tier object that passes the new TypeScript type but lacks `amount` (e.g., `{ to: 100, flatAmount: 50 }`) will fail Zod validation at runtime, leaving the fix incomplete and potentially misleading to SDK consumers.
- `typegen/genUtils/TypeGenerator.ts` (line 334 — hardcoded UsageTierSchema), `atmn/src/compose/models/planModels.ts` (lines 7–10 — generated UsageTierSchema)

<details><summary><h3>Class Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class PriceBaseFields {
        +billingMethod: BillingMethod
        +billingUnits?: number
        +maxPurchase?: number
    }

    class PriceWithAmount {
        +amount: number
        +tiers?: never
    }

    class PriceWithGraduatedTiers {
        +amount?: never
        +tiers: Array~GraduatedTier~
        +tierBehavior: "graduated"
    }

    class GraduatedTier {
        +to: number | "inf"
        +amount: number
    }

    class PriceWithVolumeTiers {
        +billingMethod: Exclude~BillingMethod,"usage_based"~
        +amount?: never
        +tiers: Array~VolumeTier~
        +tierBehavior: "volume"
    }

    class VolumeTier {
        +to: number | "inf"
        +amount?: number
        +flatAmount?: number
    }

    note for VolumeTier "At least one of amount or flatAmount required\n⚠ UsageTierSchema requires amount (no flatAmount)"

    PriceBaseFields <|-- PriceWithAmount
    PriceBaseFields <|-- PriceWithGraduatedTiers
    PriceBaseFields <|-- PriceWithVolumeTiers
    PriceWithGraduatedTiers --> GraduatedTier
    PriceWithVolumeTiers --> VolumeTier
```
</details>


<sub>Last reviewed commit: 4b6532c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->