### PR TITLE
feat: 🎸 nuke safely

### DIFF
--- a/atmn/src/lib/api/endpoints/customers.ts
+++ b/atmn/src/lib/api/endpoints/customers.ts
@@ -38,7 +38,7 @@ export interface FetchCustomersResponse {
 }
 
 /**
- * Fetch all customers using V1 endpoint (GET with query params)
+ * Fetch a single page of customers
  */
 export async function fetchCustomers(
 	options: FetchCustomersOptions,
@@ -56,6 +56,36 @@ export async function fetchCustomers(
 	});
 
 	return response.list;
+}
+
+/**
+ * Fetch all customers across all pages
+ */
+export async function fetchAllCustomers({
+	secretKey,
+}: {
+	secretKey: string;
+}): Promise<ApiCustomer[]> {
+	const all: ApiCustomer[] = [];
+	const limit = 100;
+	let offset = 0;
+
+	while (true) {
+		const response = await request<FetchCustomersResponse>({
+			method: "GET",
+			path: "/v1/customers",
+			secretKey,
+			queryParams: { limit, offset },
+		});
+
+		all.push(...response.list);
+
+		if (response.list.length < limit) break;
+
+		offset += limit;
+	}
+
+	return all;
 }
 
 /**

--- a/atmn/src/lib/hooks/useNuke.ts
+++ b/atmn/src/lib/hooks/useNuke.ts
@@ -16,7 +16,7 @@ import type {
 import {
 	type ApiCustomer,
 	deleteCustomer,
-	fetchCustomers,
+	fetchAllCustomers,
 } from "../api/endpoints/customers.js";
 import { deleteFeature, fetchFeatures } from "../api/endpoints/features.js";
 import { deletePlan, fetchPlans } from "../api/endpoints/plans.js";
@@ -102,7 +102,7 @@ export function useNuke(options?: UseNukeOptions): UseNukeReturn {
 			const customersPhaseStart = Date.now();
 			setActivePhase("customers");
 
-			const customers = await fetchCustomers({ secretKey });
+			const customers = await fetchAllCustomers({ secretKey });
 			setPhases((prev) =>
 				prev.map((p) =>
 					p.phase === "customers" ? { ...p, total: customers.length } : p,

--- a/atmn/src/lib/hooks/useNukeData.ts
+++ b/atmn/src/lib/hooks/useNukeData.ts
@@ -3,7 +3,7 @@
  */
 
 import { useQuery } from "@tanstack/react-query";
-import { fetchCustomers } from "../api/endpoints/customers.js";
+import { fetchAllCustomers } from "../api/endpoints/customers.js";
 import { fetchFeatures } from "../api/endpoints/features.js";
 import { fetchOrganizationMe } from "../api/endpoints/index.js";
 import { fetchPlans } from "../api/endpoints/plans.js";
@@ -30,7 +30,7 @@ export function useNukeData() {
 			// Fetch all data in parallel
 			const [org, customers, plans, features] = await Promise.all([
 				fetchOrganizationMe({ secretKey }),
-				fetchCustomers({ secretKey }),
+				fetchAllCustomers({ secretKey }),
 				fetchPlans({ secretKey, includeArchived: true }),
 				fetchFeatures({ secretKey }),
 			]);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes nuke to fetch all customers across pages, preventing partial deletion and wrong counts. Adds a paginated fetch and updates nuke hooks to use it.

- **Bug Fixes**
  - Implemented fetchAllCustomers that iterates pages with limit/offset.
  - Switched useNuke and useNukeData to use fetchAllCustomers instead of single-page fetch.

<sup>Written for commit ecd27a08f621ddb5dd88735bd539c6b1178ae495. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a critical bug where the nuke operation only deleted the first page (up to 100) of customers by introducing a `fetchAllCustomers` function that paginates through all pages. Both the nuke executor (`useNuke`) and the nuke preview UI (`useNukeData`) are updated to use the new function.

**Key changes:**
- **Bug fixes** | Added `fetchAllCustomers` in `customers.ts` — a paginating wrapper that loops until all customer pages are retrieved, fixing the silent data-loss bug where the nuke operation left customers behind after the first 100.
- **Improvements** | `useNuke` now uses `fetchAllCustomers`, ensuring the deletion phase operates on the complete customer list rather than a truncated first page.
- **Improvements** | `useNukeData` now uses `fetchAllCustomers` so the confirmation screen displays the accurate total customer count instead of a capped-at-100 value.
- **API changes** | `fetchCustomers` is updated in its JSDoc to reflect it only fetches a single page, making the single-page vs. all-pages distinction explicit in the API surface.
</details>

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the core nuke fix is correct; two minor style improvements are recommended but are not blockers.
- The pagination logic in `fetchAllCustomers` is correct and addresses a real bug. The two flagged items are non-critical: using `has_more` instead of a length comparison is a style improvement, and the over-fetching in `useNukeData` is a performance concern but does not cause incorrect behaviour.
- `atmn/src/lib/hooks/useNukeData.ts` — fetches all customer pages for a count-only display; consider using the API's `total` field instead.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| atmn/src/lib/api/endpoints/customers.ts | Adds `fetchAllCustomers` with a `while(true)` pagination loop. Logic is correct but uses `list.length < limit` instead of the existing `has_more` flag, causing one extra API call when the total is an exact multiple of the page size. |
| atmn/src/lib/hooks/useNuke.ts | Correctly swaps `fetchCustomers` for `fetchAllCustomers` so the nuke operation now deletes all customers across all pages, not just the first 100. |
| atmn/src/lib/hooks/useNukeData.ts | Swaps `fetchCustomers` for `fetchAllCustomers` for the preview UI, but this now paginates through all customers just to display a count — the API's `total` field would satisfy this with a single request. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Nuke UI
    participant useNukeData
    participant useNuke
    participant fetchAllCustomers
    participant API as /v1/customers

    UI->>useNukeData: mount (preview)
    useNukeData->>fetchAllCustomers: fetchAllCustomers({ secretKey })
    loop until has_more is false / list.length < limit
        fetchAllCustomers->>API: GET /v1/customers?limit=100&offset=N
        API-->>fetchAllCustomers: { list, total, has_more }
    end
    fetchAllCustomers-->>useNukeData: ApiCustomer[]
    useNukeData-->>UI: customersCount (customers.length)

    UI->>useNuke: nuke()
    useNuke->>fetchAllCustomers: fetchAllCustomers({ secretKey })
    loop until has_more is false / list.length < limit
        fetchAllCustomers->>API: GET /v1/customers?limit=100&offset=N
        API-->>fetchAllCustomers: { list, total, has_more }
    end
    fetchAllCustomers-->>useNuke: ApiCustomer[]
    loop for each customer
        useNuke->>API: DELETE /v1/customers/:id
    end
    useNuke-->>UI: phases updated / complete
```
</details>

<sub>Last reviewed commit: ecd27a0</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->