### PR TITLE
fix: type properties as record on events list schema (untested)

### DIFF
--- a/package/src/sdk/events/eventTypes.ts
+++ b/package/src/sdk/events/eventTypes.ts
@@ -63,7 +63,7 @@ export const EventsListItemSchema = z.object({
 	feature_id: z.string().describe("Name of the event"),
 	customer_id: z.string().describe("Customer identifier"),
 	value: z.number().describe("Event value/count"),
-	properties: z.object({}).describe("Event properties (JSONB)"),
+	properties: z.record(z.string(), z.unknown()).describe("Event properties (JSONB)"),
 });
 
 export type EventsListItem = z.infer<typeof EventsListItemSchema>;


### PR DESCRIPTION
## Summary
Fixes the SDK events list schema so `properties` supports arbitrary JSON values.

## Related Issues
Fixes an issue where `properties` was not being returned correctly in the SDK.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
N/A

## Additional Context
Changes `properties` from an empty object schema to a record in the SDK.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the events list schema so `properties` supports arbitrary JSON and returns correctly in the SDK. Replaces `z.object({})` with `z.record(z.string(), z.unknown())` to match JSONB storage.

<sup>Written for commit 51e86c16167b45d7d568ccd5b5cf3c505530b7b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects the Zod schema for `EventsListItemSchema.properties`, replacing the semantically incorrect `z.object({})` with `z.record(z.string(), z.unknown())`, which properly represents arbitrary JSONB key-value data returned by the events list API.

**Key changes:**

- [Bug fix] `properties` in `EventsListItemSchema` was typed as `z.object({})`, which in Zod validates only an empty object and strips or rejects all actual properties at runtime — incorrect for a JSONB column that holds arbitrary data.
- [Improvements, API changes] The inferred TypeScript type for `EventsListItem.properties` changes from `{}` to `Record<string, unknown>`, now accurately reflecting the data shape returned by the API. Existing consumers (`Object.keys()` and `JSON.stringify()` in `event-list-viewer.tsx`) are fully compatible with this new type.

> **Note:** The PR title explicitly marks this change as "untested" and the author left the "I have tested my changes locally" checklist item unchecked. While the code change is logically correct, it has not been verified against a live environment.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — targeted, correct fix for an incorrect Zod schema type with no breaking consumers

Single-line change is logically correct: z.record(z.string(), z.unknown()) properly represents JSONB data. No existing code is broken by the type change (only usages are Object.keys() and JSON.stringify()). Minor concern is that the author self-flagged the change as untested.

No files require special attention; the change is minimal and isolated to a single schema definition.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package/src/sdk/events/eventTypes.ts | Fixes `properties` schema from restrictive empty object to `Record<string, unknown>`, correctly representing arbitrary JSONB data |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant SDK as Autumn SDK
    participant API as Autumn API

    C->>SDK: events.list(params)
    SDK->>API: GET /events (paginated)
    API-->>SDK: JSON response with properties (JSONB)
    SDK->>SDK: Parse via EventsListItemSchema
    Note over SDK: properties: z.record(z.string(), z.unknown())<br/>Previously: z.object({}) — stripped all props
    SDK-->>C: EventsListItem[] with full properties
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: type properties as record on events..."](https://github.com/useautumn/typescript/commit/51e86c16167b45d7d568ccd5b5cf3c505530b7b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27459230)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->