### PR TITLE
Add atmn npm issue tracker metadata

### DIFF
--- a/atmn/package.json
+++ b/atmn/package.json
@@ -1,6 +1,15 @@
 {
 	"name": "atmn",
 	"version": "0.0.36",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/useautumn/typescript",
+		"directory": "atmn"
+	},
+	"homepage": "https://docs.useautumn.com/api-reference/cli/getting-started",
+	"bugs": {
+		"url": "https://github.com/useautumn/typescript/issues"
+	},
 	"license": "MIT",
 	"bin": "dist/cli.js",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Add package source metadata for the `atmn` workspace package.
- Keep the existing CLI docs homepage in package metadata.
- Add `bugs.url` so npm users can reach the public GitHub issue tracker.

## Verification
- Metadata smoke check from `atmn/`
- `npm pack --dry-run --ignore-scripts` from `atmn/`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add npm metadata to the `atmn` package to improve discoverability and support. Includes repository source (repo URL and `atmn` directory), sets homepage to the CLI docs, and adds `bugs.url` pointing to GitHub issues.

<sup>Written for commit 07636b78f082ba4a0c49b6ba8b05f6e41324f1bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/typescript/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

